### PR TITLE
Initial Setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 KUBERNETES_DNS_SERVICE_IP=127.0.0.1
-BACKEND_API_1=backend-api-1.svc
-BACKEND_API_2=backend-api-2.svc
+SERVICE_HOST_API=api.svc
+SERVICE_HOST_FRONTEND=frontend.svc
+SERVICE_HOST_WEB=web.svc

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+.idea
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/http-server.conf
+++ b/http-server.conf
@@ -20,5 +20,5 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-    default_type application/json;
+    default_type text/html;
 }

--- a/routes.conf.template
+++ b/routes.conf.template
@@ -1,19 +1,14 @@
-location ~* ^/api/v1/user/(.*)/app/(.*)/index/(.*)/search/?(.*)$ {
-    proxy_pass http://$BACKEND_API_1/api/v1/user/$1/app/$2/index/$3/search/$4$is_args$args;
-}
-
-location ~* ^/api/v1/vs/(.*)$ {
-    proxy_pass http://$BACKEND_API_2$request_uri;
-}
-
+# Forward to API Service => /api/*
 location ~* ^/api/(.*)$ {
-    proxy_pass http://$BACKEND_API_1$request_uri;
+    proxy_pass http://$SERVICE_API_HOST$request_uri;
 }
 
-location ~* ^/visualsearch/(.*)$ {
-    proxy_pass http://$BACKEND_API_2$request_uri;
+# Forward to Frontend Service => /app/*
+location ~* ^/app/(.*)$ {
+    proxy_pass http://$SERVICE_FRONTEND_HOST$request_uri;
 }
 
+# Forward to Web Service => /*
 location ~* ^/(.*)$ {
-    proxy_pass http://$BACKEND_API_1$request_uri;
+    proxy_pass http://$SERVICE_WEB_HOST$request_uri;
 }

--- a/run.sh
+++ b/run.sh
@@ -42,7 +42,7 @@ printf "search FQDN: %s\n\n" "$fqdn"
 
 printf "--------- GENERATED ROUTES.CONF ------------\n"
 cat /etc/nginx/routes.conf
-printf "--------- EOF GENERTED ROUTES.CONF ---------\n"
+printf "--------- EOF GENERATED ROUTES.CONF ---------\n"
 
 printf "> nginx.conf and routes.conf configuration files loaded!\n\n"
 


### PR DESCRIPTION
Initial Setup includes rules for:

- `/api/*` routes to API service
- `/app/*` routes to Frontend service
- `/*` routes to Web service